### PR TITLE
feat: UI polish — camera zoom, progress bar, responsive, help overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hawkins
 
-An interactive spatio-temporal map of Hawkins, Indiana from _Stranger Things_ — explore key moments from Season 1 on an animated SVG map.
+An interactive spatio-temporal map of Hawkins, Indiana from _Stranger Things_ — explore key moments across all 5 seasons on an animated map.
 
 **[View Live Demo →](https://ki-seki.github.io/hawkins/)**
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,63 @@
 import { useEffect, useRef, useState } from 'react'
-import { motion } from 'framer-motion'
+import { AnimatePresence, motion } from 'framer-motion'
 import { useAtlasStore, useTimeline } from './store'
 import { momentsSorted, episodesById } from './data/catalog'
 import { HawkinsMap } from './components/Map'
 import { Timeline } from './components/Timeline'
 import { InfoCard } from './components/InfoCard'
+
+// ─── HelpOverlay ─────────────────────────────────────────────────────────────
+
+const SHORTCUTS = [
+  { keys: ['←', '→'], label: 'Navigate moments' },
+  { keys: ['Space'], label: 'Play / Pause autoplay' },
+  { keys: ['1', '–', '5'], label: 'Jump to season' },
+  { keys: ['Esc'], label: 'Close panel' },
+  { keys: ['?'], label: 'Toggle this help' },
+]
+
+function HelpOverlay({ onClose }: { onClose: () => void }) {
+  return (
+    <motion.div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.2 }}
+    >
+      <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={onClose} />
+      <motion.div
+        className="relative bg-dim/95 border border-white/10 rounded-xl p-6 sm:p-8 max-w-sm w-[calc(100%-2rem)]"
+        initial={{ scale: 0.9, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        exit={{ scale: 0.9, opacity: 0 }}
+        transition={{ duration: 0.2, ease: 'easeOut' }}
+      >
+        <h2 className="text-white font-display text-lg mb-5 tracking-wide">Keyboard Shortcuts</h2>
+        <div className="space-y-3">
+          {SHORTCUTS.map(({ keys, label }) => (
+            <div key={label} className="flex items-center justify-between gap-4">
+              <span className="text-white/60 text-sm font-sans">{label}</span>
+              <div className="flex items-center gap-1">
+                {keys.map((k, i) => (
+                  <kbd
+                    key={i}
+                    className="inline-flex items-center justify-center min-w-[1.75rem] h-6 px-1.5 rounded bg-white/10 border border-white/15 text-white/80 font-mono text-[11px]"
+                  >
+                    {k}
+                  </kbd>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+        <p className="text-white/25 text-[10px] font-mono mt-5 text-center tracking-wider uppercase">
+          Press Esc or click outside to close
+        </p>
+      </motion.div>
+    </motion.div>
+  )
+}
 
 // ─── IntroAnimation ───────────────────────────────────────────────────────────
 
@@ -68,6 +121,7 @@ export default function App() {
   const { currentMoment, next, prev, hasNext, hasPrev } = useTimeline()
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const [showIntro, setShowIntro] = useState(true)
+  const [showHelp, setShowHelp] = useState(false)
 
   // Pause autoplay on user interaction
   useEffect(() => {
@@ -116,7 +170,9 @@ export default function App() {
           break
         case 'Escape':
           e.preventDefault()
-          if (selectedEntity) {
+          if (showHelp) {
+            setShowHelp(false)
+          } else if (selectedEntity) {
             clearSelected()
           }
           break
@@ -139,12 +195,16 @@ export default function App() {
           if (first) useAtlasStore.getState().setMoment(first.id)
           break
         }
+        case '?':
+          e.preventDefault()
+          setShowHelp((v) => !v)
+          break
       }
     }
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [hasNext, hasPrev, next, prev, selectedEntity, clearSelected, isPlaying, setPlaying])
+  }, [hasNext, hasPrev, next, prev, selectedEntity, clearSelected, isPlaying, setPlaying, showHelp])
 
   return (
     <div className="relative w-screen h-screen overflow-hidden bg-dim" role="application" aria-label="Hawkins Interactive Map">
@@ -162,15 +222,15 @@ export default function App() {
       </div>
 
       {/* Moment title overlay (top-left) */}
-      <div className="absolute top-4 left-4 pointer-events-none z-10 max-w-xs" role="status" aria-live="polite">
-        <div className="bg-black/50 backdrop-blur-sm border border-white/10 rounded-lg px-4 py-3">
-          <p className="text-hawkins-amber/80 font-mono text-[10px] uppercase tracking-[0.2em] mb-1">
+      <div className="absolute top-3 left-3 sm:top-4 sm:left-4 pointer-events-none z-10 max-w-[200px] sm:max-w-xs" role="status" aria-live="polite">
+        <div className="bg-black/50 backdrop-blur-sm border border-white/10 rounded-lg px-3 py-2 sm:px-4 sm:py-3">
+          <p className="text-hawkins-amber/80 font-mono text-[9px] sm:text-[10px] uppercase tracking-[0.2em] mb-1">
             {currentMoment?.timeLabel}
           </p>
-          <h1 className="text-white font-display text-xl leading-tight font-medium">
+          <h1 className="text-white font-display text-base sm:text-xl leading-tight font-medium">
             {currentMoment?.title}
           </h1>
-          <p className="text-white/55 text-xs mt-1.5 leading-relaxed font-sans">
+          <p className="text-white/55 text-[10px] sm:text-xs mt-1 sm:mt-1.5 leading-relaxed font-sans line-clamp-2 sm:line-clamp-none">
             {currentMoment?.summary}
           </p>
         </div>
@@ -183,9 +243,14 @@ export default function App() {
       <InfoCard />
 
       {/* Keyboard shortcuts hint */}
-      <div className="fixed bottom-16 left-4 text-white/30 text-xs font-mono pointer-events-none z-10" aria-hidden="true">
-        <p>← → Navigate • Space Play/Pause • 1-5 Seasons • Esc Close</p>
+      <div className="hidden md:block fixed bottom-16 left-4 text-white/30 text-xs font-mono pointer-events-none z-10" aria-hidden="true">
+        <p>← → Navigate • Space Play/Pause • 1-5 Seasons • Esc Close • ? Help</p>
       </div>
+
+      {/* Help overlay */}
+      <AnimatePresence>
+        {showHelp && <HelpOverlay onClose={() => setShowHelp(false)} />}
+      </AnimatePresence>
     </div>
   )
 }

--- a/src/components/InfoCard.tsx
+++ b/src/components/InfoCard.tsx
@@ -32,7 +32,7 @@ export function InfoCard() {
           animate={{ x: 0, opacity: 1 }}
           exit={{ x: 40, opacity: 0 }}
           transition={{ duration: 0.25, ease: 'easeOut' }}
-          className="fixed right-0 top-0 bottom-14 z-20 w-80 bg-dim/95 backdrop-blur-md border-l border-white/10 flex flex-col overflow-hidden"
+          className="fixed right-0 top-0 bottom-14 z-20 w-full sm:w-80 bg-dim/95 backdrop-blur-md border-l border-white/10 flex flex-col overflow-hidden"
           role="dialog"
           aria-labelledby="infocard-title"
           aria-describedby="infocard-description"

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1,8 +1,12 @@
 import { AnimatePresence, motion } from 'framer-motion'
 import { useEffect, useRef, useState, useMemo, useCallback, memo } from 'react'
 import { useAtlasStore, useMomentState } from '../store'
-import { mapLayout } from '../data/catalog'
+import { mapLayout, locationsById, momentsSorted } from '../data/catalog'
 import type { Location, Character } from '../data/catalog'
+
+const FOCUS_SCALE = 1.8
+const FOCUS_DURATION = 0.8
+const BASE_SCALE = 1.15
 
 // ─── ThemeOverlay ─────────────────────────────────────────────────────────────
 
@@ -217,6 +221,77 @@ const CharacterMarker = memo(function CharacterMarker({
   )
 })
 
+// ─── CharacterMovementLines ──────────────────────────────────────────────────
+
+interface MovementLine {
+  characterId: string
+  color: string
+  fromX: number
+  fromY: number
+  toX: number
+  toY: number
+}
+
+function CharacterMovementLines({
+  currentMomentId,
+  containerSize,
+}: {
+  currentMomentId: string
+  containerSize: { w: number; h: number }
+}) {
+  const currentIdx = momentsSorted.findIndex((m) => m.id === currentMomentId)
+  const prevMomentId = currentIdx > 0 ? momentsSorted[currentIdx - 1].id : currentMomentId
+
+  const currentResolved = useMomentState(currentMomentId)
+  const prevResolved = useMomentState(prevMomentId)
+  const hasPrev = currentIdx > 0
+
+  const lines = useMemo(() => {
+    if (!currentResolved || !prevResolved || !hasPrev) return []
+    const result: MovementLine[] = []
+    for (const curChar of currentResolved.activeCharacters) {
+      const prevChar = prevResolved.activeCharacters.find((c) => c.id === curChar.id)
+      if (!prevChar || prevChar.locationId === curChar.locationId) continue
+      const fromLoc = locationsById.get(prevChar.locationId)
+      const toLoc = locationsById.get(curChar.locationId)
+      if (!fromLoc || !toLoc) continue
+      result.push({
+        characterId: curChar.id,
+        color: curChar.color,
+        fromX: (fromLoc.map.x / 100) * containerSize.w,
+        fromY: (fromLoc.map.y / 100) * containerSize.h,
+        toX: (toLoc.map.x / 100) * containerSize.w,
+        toY: (toLoc.map.y / 100) * containerSize.h,
+      })
+    }
+    return result
+  }, [currentResolved, prevResolved, containerSize, hasPrev])
+
+  if (lines.length === 0) return null
+
+  return (
+    <>
+      {lines.map((line) => (
+        <motion.line
+          key={`${line.characterId}-${line.fromX}-${line.toX}`}
+          x1={line.fromX}
+          y1={line.fromY}
+          x2={line.toX}
+          y2={line.toY}
+          stroke={line.color}
+          strokeWidth={1.5}
+          strokeDasharray="6 4"
+          strokeLinecap="round"
+          opacity={0.6}
+          initial={{ pathLength: 0, opacity: 0 }}
+          animate={{ pathLength: 1, opacity: 0.6 }}
+          transition={{ duration: 0.6, ease: 'easeOut' }}
+        />
+      ))}
+    </>
+  )
+}
+
 // ─── HawkinsMap ───────────────────────────────────────────────────────────────
 
 export function HawkinsMap() {
@@ -256,53 +331,86 @@ export function HawkinsMap() {
 
   const layout = mapLayout as { svgPath: string }
 
+  // Camera: compute transform for focusLocationId
+  const focusLocation = resolved?.moment.focusLocationId
+    ? locationsById.get(resolved.moment.focusLocationId)
+    : null
+  const cameraTransform = useMemo(() => {
+    if (!focusLocation) {
+      const tx = (size.w * (1 - BASE_SCALE)) / 2
+      const ty = (size.h * (1 - BASE_SCALE)) / 2
+      return { scale: BASE_SCALE, x: tx, y: ty }
+    }
+    const cx = (focusLocation.map.x / 100) * size.w
+    const cy = (focusLocation.map.y / 100) * size.h
+    const tx = size.w / 2 - cx * FOCUS_SCALE
+    const ty = size.h / 2 - cy * FOCUS_SCALE
+    return { scale: FOCUS_SCALE, x: tx, y: ty }
+  }, [focusLocation, size.w, size.h])
+
   return (
-    <div ref={containerRef} className="relative w-full h-full" onClick={handleMapClick}>
-      <img
-        src={`${import.meta.env.BASE_URL}${layout.svgPath}`}
-        alt="Hawkins map"
-        className="absolute inset-0 w-full h-full"
-        style={{ objectFit: 'fill' }}
-        draggable={false}
-      />
-
-      <ThemeOverlay momentId={currentMomentId} />
-
-      <AnimatePresence mode="wait">
-        <motion.svg
-          key={currentMomentId}
+    <div ref={containerRef} className="relative w-full h-full overflow-hidden" style={{ backgroundColor: '#0d0d14' }} onClick={handleMapClick}>
+      <motion.div
+        className="relative w-full h-full"
+        animate={{ scale: cameraTransform.scale, x: cameraTransform.x, y: cameraTransform.y }}
+        transition={{ duration: FOCUS_DURATION, ease: [0.25, 0.1, 0.25, 1] }}
+        style={{ transformOrigin: '0 0' }}
+      >
+        <img
+          src={`${import.meta.env.BASE_URL}${layout.svgPath}`}
+          alt="Hawkins map"
           className="absolute inset-0 w-full h-full"
-          viewBox={`0 0 ${size.w} ${size.h}`}
-          preserveAspectRatio="none"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.4 }}
-        >
-          {resolved?.activeLocations.map((loc) => (
-            <LocationMarker
-              key={loc.id}
-              location={loc}
-              containerSize={size}
-              isSelected={selectedEntity?.type === 'location' && selectedEntity.id === loc.id}
-            />
-          ))}
-          {resolved?.activeLocations.map((loc) => {
-            const chars = charsByLocation[loc.id] ?? []
-            return chars.map((char, idx) => (
-              <CharacterMarker
-                key={char.id}
-                character={char}
-                locationX={loc.map.x}
-                locationY={loc.map.y}
+          style={{ objectFit: 'cover' }}
+          draggable={false}
+        />
+
+        <ThemeOverlay momentId={currentMomentId} />
+
+        {/* Map edge fade — blends map edges into background */}
+        <div
+          className="absolute inset-0 pointer-events-none"
+          style={{
+            background: 'radial-gradient(ellipse at center, transparent 50%, #0d0d14 100%)',
+          }}
+        />
+
+        <AnimatePresence mode="wait">
+          <motion.svg
+            key={currentMomentId}
+            className="absolute inset-0 w-full h-full"
+            viewBox={`0 0 ${size.w} ${size.h}`}
+            preserveAspectRatio="none"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.4 }}
+          >
+            <CharacterMovementLines currentMomentId={currentMomentId} containerSize={size} />
+            {resolved?.activeLocations.map((loc) => (
+              <LocationMarker
+                key={loc.id}
+                location={loc}
                 containerSize={size}
-                index={idx}
-                isSelected={selectedEntity?.type === 'character' && selectedEntity.id === char.id}
+                isSelected={selectedEntity?.type === 'location' && selectedEntity.id === loc.id}
               />
-            ))
-          })}
-        </motion.svg>
-      </AnimatePresence>
+            ))}
+            {resolved?.activeLocations.map((loc) => {
+              const chars = charsByLocation[loc.id] ?? []
+              return chars.map((char, idx) => (
+                <CharacterMarker
+                  key={char.id}
+                  character={char}
+                  locationX={loc.map.x}
+                  locationY={loc.map.y}
+                  containerSize={size}
+                  index={idx}
+                  isSelected={selectedEntity?.type === 'character' && selectedEntity.id === char.id}
+                />
+              ))
+            })}
+          </motion.svg>
+        </AnimatePresence>
+      </motion.div>
     </div>
   )
 }

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,17 +1,20 @@
+import { useState, useRef, useCallback } from 'react'
+import { motion } from 'framer-motion'
 import { useTimeline, useAtlasStore } from '../store'
-import { episodesById, momentsSorted } from '../data/catalog'
+import { episodesById, momentsSorted, getSeason } from '../data/catalog'
+import type { Moment } from '../data/catalog'
 
 const SEASONS = [1, 2, 3, 4, 5] as const
-
-function getSeason(moment: { episodeId: string }): number {
-  const ep = episodesById.get(moment.episodeId)
-  return ep?.season ?? 1
-}
 
 function getEpisodeLabel(episodeId: string): string {
   const ep = episodesById.get(episodeId)
   if (!ep) return ''
   return `S${String(ep.season).padStart(2, '0')}E${String(ep.episode).padStart(2, '0')}`
+}
+
+interface TooltipState {
+  moment: Moment
+  x: number
 }
 
 export function Timeline() {
@@ -20,6 +23,17 @@ export function Timeline() {
   const setPlaying = useAtlasStore((s) => s.setPlaying)
   const currentSeason = useAtlasStore((s) => s.currentSeason)
   const setCurrentSeason = useAtlasStore((s) => s.setCurrentSeason)
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null)
+  const dotsRef = useRef<HTMLDivElement>(null)
+
+  const handleDotHover = useCallback((m: Moment, e: React.MouseEvent) => {
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+    const containerRect = dotsRef.current?.getBoundingClientRect()
+    if (!containerRect) return
+    setTooltip({ moment: m, x: rect.left + rect.width / 2 - containerRect.left })
+  }, [])
+
+  const handleDotLeave = useCallback(() => setTooltip(null), [])
 
   return (
     <div
@@ -30,7 +44,18 @@ export function Timeline() {
         borderTop: '1px solid rgba(245,127,23,0.12)',
       }}
     >
-      <div className="flex items-center h-full px-5 gap-3">
+      {/* Season progress bar */}
+      <div className="absolute top-0 left-0 right-0 h-[2px] bg-white/5">
+        <motion.div
+          className="h-full bg-hawkins-amber/60"
+          initial={false}
+          animate={{ width: moments.length > 1 ? `${(currentIndex / (moments.length - 1)) * 100}%` : '0%' }}
+          transition={{ duration: 0.4, ease: 'easeOut' }}
+          style={{ boxShadow: '0 0 6px rgba(245,127,23,0.3)' }}
+        />
+      </div>
+
+      <div className="flex items-center h-full px-3 sm:px-5 gap-2 sm:gap-3">
 
         {/* Season selector */}
         <div className="flex-shrink-0 flex items-center gap-1">
@@ -57,7 +82,7 @@ export function Timeline() {
         </div>
 
         {/* Episode + moment title */}
-        <div className="flex-shrink-0 flex items-center gap-2 min-w-0 w-44">
+        <div className="hidden sm:flex flex-shrink-0 items-center gap-2 min-w-0 w-44">
           <span
             className="font-mono text-[11px] tracking-[0.25em] uppercase text-hawkins-amber flex-shrink-0"
             style={{ textShadow: '0 0 10px rgba(245,127,23,0.6)' }}
@@ -83,7 +108,7 @@ export function Timeline() {
         </button>
 
         {/* Timeline dots */}
-        <div className="flex-1 flex items-center gap-[3px] overflow-x-auto" style={{ scrollbarWidth: 'none' }}>
+        <div ref={dotsRef} className="relative flex-1 flex items-center gap-[3px] overflow-x-auto" style={{ scrollbarWidth: 'none' }}>
           {moments.map((m, idx) => {
             const isActive = m.id === currentMoment?.id
             const isPast = idx < currentIndex
@@ -91,7 +116,8 @@ export function Timeline() {
               <button
                 key={m.id}
                 onClick={() => seek(m.id)}
-                title={m.title}
+                onMouseEnter={(e) => handleDotHover(m, e)}
+                onMouseLeave={handleDotLeave}
                 className={[
                   'flex-shrink-0 rounded-full transition-all duration-300',
                   isActive
@@ -106,6 +132,21 @@ export function Timeline() {
               />
             )
           })}
+          {tooltip && (
+            <div
+              className="absolute bottom-full mb-2 pointer-events-none z-50"
+              style={{ left: tooltip.x, transform: 'translateX(-50%)' }}
+            >
+              <div className="bg-black/90 backdrop-blur-sm border border-white/10 rounded px-2.5 py-1.5 whitespace-nowrap">
+                <p className="text-hawkins-amber/80 font-mono text-[9px] tracking-[0.15em] uppercase">
+                  {getEpisodeLabel(tooltip.moment.episodeId)}
+                </p>
+                <p className="text-white/90 font-mono text-[10px] tracking-wide mt-0.5">
+                  {tooltip.moment.title}
+                </p>
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Next */}

--- a/src/data/catalog.ts
+++ b/src/data/catalog.ts
@@ -256,6 +256,11 @@ export const momentStatesById = new Map(momentStates.map((ms) => [ms.momentId, m
 // Sorted moments for timeline (cached)
 export const momentsSorted = [...moments].sort((a, b) => a.sortKey - b.sortKey)
 
+export function getSeason(moment: Moment): number {
+  const ep = episodesById.get(moment.episodeId)
+  return ep?.season ?? 1
+}
+
 // Helper to get entity by type and id
 export function getEntityById(
   type: 'character' | 'location' | 'event',

--- a/src/store.ts
+++ b/src/store.ts
@@ -5,7 +5,7 @@ import {
   momentStatesById,
   charactersById,
   locationsById,
-  episodesById,
+  getSeason,
 } from './data/catalog'
 import type { Character, Location, Moment, MomentState } from './data/catalog'
 
@@ -41,11 +41,6 @@ export const useAtlasStore = create<AtlasStore>((set) => ({
 }))
 
 // ─── useTimeline ──────────────────────────────────────────────────────────────
-
-function getSeason(moment: Moment): number {
-  const ep = episodesById.get(moment.episodeId)
-  return ep?.season ?? 1
-}
 
 export function useTimeline() {
   const currentMomentId = useAtlasStore((s) => s.currentMomentId)
@@ -91,7 +86,7 @@ export function useTimeline() {
         if (prevSeasonMoments.length > 0) setMoment(prevSeasonMoments[prevSeasonMoments.length - 1].id)
       }
     },
-    hasNext: currentIndex < seasonMoments.length - 1 || currentSeason < 4,
+    hasNext: currentIndex < seasonMoments.length - 1 || currentSeason < 5,
     hasPrev: currentIndex > 0 || currentSeason > 1,
   }
 }


### PR DESCRIPTION
## Summary
- Fix `hasNext` boundary bug (S4→S5 transition was blocked)
- Deduplicate `getSeason` into `catalog.ts`
- Camera pan/zoom to `focusLocationId` with smooth animation
- Season progress bar at top of timeline
- Character movement lines between moments
- Styled tooltip on timeline dot hover
- Mobile responsive layout (InfoCard full-width, smaller overlays, hidden keyboard hint)
- Keyboard shortcut help overlay (press `?`)
- Map edge fade with radial gradient + `object-fit: cover` + 1.15x base scale to eliminate black edges

## Test plan
- [ ] Navigate through S1→S5 moments, verify no black edges on map
- [ ] Test camera zoom on moments with `focusLocationId`
- [ ] Hover timeline dots, verify tooltip appears
- [ ] Press `?`, verify help overlay shows
- [ ] Resize to mobile width, verify layout adapts
- [ ] Verify character movement lines appear when characters change location

🤖 Generated with [Claude Code](https://claude.com/claude-code)